### PR TITLE
Better destination management

### DIFF
--- a/lib/evva/templates/swift/people_properties.swift
+++ b/lib/evva/templates/swift/people_properties.swift
@@ -9,15 +9,25 @@ struct PropertyData {
 		self.destinations = destinations
 	}
 
-	init(name: PropertyName, value: Any, destinations: [Destination]) {
-		self.init(name: name.rawValue, value: value, destinations: destinations)
+	init(type: PropertyType, value: Any) {
+		self.init(name: type.name, value: value, destinations: type.destinations)
 	}
 }
 
-enum PropertyName: String {
+enum PropertyType: String {
 	<%- properties.each do |p| -%>
 	case <%= p[:case_name] %> = "<%= p[:property_name ] %>"
 	<%- end -%>
+
+	var name: String { return rawValue }
+
+	var destinations: [Destination] {
+		switch self {
+		<%- properties.each_with_index do |p, index| -%>
+		case .<%= p[:case_name] %>: return [<%= p[:destinations].map { |d| ".#{d}" }.join(", ") %>]
+		<%- end -%>
+		}
+	}
 }
 
 enum Property {
@@ -29,17 +39,8 @@ enum Property {
 		switch self {
 		<%- properties.each_with_index do |p, index| -%>
 		case let .<%= p[:case_name] %>(value):
-			return PropertyData(name: .<%= p[:case_name] %>,
-								value: value<% if p[:is_special_property] %>.rawValue<% end %>,
-			<%- if p[:destinations].count == 0 -%>
-								destinations: [])
-			<%- else -%>
-								destinations: [
-				<%- p[:destinations].each do |d| -%>
-									.<%= d %>,
-				<%- end -%>
-								])
-			<%- end -%>
+			return PropertyData(type: .<%= p[:case_name] %>,
+								value: value<% if p[:is_special_property] %>.rawValue<% end %>)
 			<%- unless index == properties.count - 1 -%>
 
 			<%- end -%>

--- a/spec/lib/evva/swift_generator_spec.rb
+++ b/spec/lib/evva/swift_generator_spec.rb
@@ -30,17 +30,29 @@ extension Analytics {
             self.destinations = destinations
         }
 
-        init(name: EventName, properties: [String: Any]?, destinations: [Destination]) {
-            self.init(name: name.rawValue, properties: properties, destinations: destinations)
+        init(type: EventType, properties: [String: Any]?) {
+            self.init(name: type.name, properties: properties, destinations: type.destinations)
         }
     }
 
-    enum EventName: String {
+    enum EventType: String {
         case cpPageView = "cp_page_view"
         case cpPageViewA = "cp_page_view_a"
         case cpPageViewB = "cp_page_view_b"
         case cpPageViewC = "cp_page_view_c"
         case cpPageViewD = "cp_page_view_d"
+
+        var name: String { return rawValue }
+
+        var destinations: [Destination] {
+            switch self {
+            case .cpPageView: return [.firebase]
+            case .cpPageViewA: return [.firebase, .customDestination]
+            case .cpPageViewB: return []
+            case .cpPageViewC: return []
+            case .cpPageViewD: return []
+            }
+        }
     }
 
     enum Event {
@@ -53,48 +65,38 @@ extension Analytics {
         var data: EventData {
             switch self {
             case .cpPageView:
-                return EventData(name: .cpPageView,
-                                 properties: nil,
-                                 destinations: [
-                                    .firebase,
-                                 ])
+                return EventData(type: .cpPageView,
+                                 properties: nil)
 
             case let .cpPageViewA(course_id, course_name):
-                return EventData(name: .cpPageViewA,
+                return EventData(type: .cpPageViewA,
                                  properties: [
                                     "course_id": course_id as Any,
                                     "course_name": course_name as Any,
-                                 ],
-                                 destinations: [
-                                    .firebase,
-                                    .customDestination,
                                  ])
 
             case let .cpPageViewB(course_id, course_name, from_screen):
-                return EventData(name: .cpPageViewB,
+                return EventData(type: .cpPageViewB,
                                  properties: [
                                     "course_id": course_id as Any,
                                     "course_name": course_name as Any,
                                     "from_screen": from_screen.rawValue as Any,
-                                 ],
-                                 destinations: [])
+                                 ])
 
             case let .cpPageViewC(course_id, course_name, from_screen):
-                return EventData(name: .cpPageViewC,
+                return EventData(type: .cpPageViewC,
                                  properties: [
                                     "course_id": course_id as Any,
                                     "course_name": course_name as Any,
                                     "from_screen": from_screen?.rawValue as Any,
-                                 ],
-                                 destinations: [])
+                                 ])
 
             case let .cpPageViewD(course_id, course_name):
-                return EventData(name: .cpPageViewD,
+                return EventData(type: .cpPageViewD,
                                  properties: [
                                     "course_id": course_id as Any,
                                     "course_name": course_name as Any,
-                                 ],
-                                 destinations: [])
+                                 ])
             }
         }
     }
@@ -163,15 +165,25 @@ extension Analytics {
             self.destinations = destinations
         }
 
-        init(name: PropertyName, value: Any, destinations: [Destination]) {
-            self.init(name: name.rawValue, value: value, destinations: destinations)
+        init(type: PropertyType, value: Any) {
+            self.init(name: type.name, value: value, destinations: type.destinations)
         }
     }
 
-    enum PropertyName: String {
+    enum PropertyType: String {
         case roundsWithWear = "rounds_with_wear"
         case wearPlatform = "wear_platform"
         case numberOfTimesItHappened = "number_of_times_it_happened"
+
+        var name: String { return rawValue }
+
+        var destinations: [Destination] {
+            switch self {
+            case .roundsWithWear: return [.firebase]
+            case .wearPlatform: return [.firebase, .customDestination]
+            case .numberOfTimesItHappened: return []
+            }
+        }
     }
 
     enum Property {
@@ -182,24 +194,16 @@ extension Analytics {
         var data: PropertyData {
             switch self {
             case let .roundsWithWear(value):
-                return PropertyData(name: .roundsWithWear,
-                                    value: value,
-                                    destinations: [
-                                        .firebase,
-                                    ])
+                return PropertyData(type: .roundsWithWear,
+                                    value: value)
 
             case let .wearPlatform(value):
-                return PropertyData(name: .wearPlatform,
-                                    value: value.rawValue,
-                                    destinations: [
-                                        .firebase,
-                                        .customDestination,
-                                    ])
+                return PropertyData(type: .wearPlatform,
+                                    value: value.rawValue)
 
             case let .numberOfTimesItHappened(value):
-                return PropertyData(name: .numberOfTimesItHappened,
-                                    value: value,
-                                    destinations: [])
+                return PropertyData(type: .numberOfTimesItHappened,
+                                    value: value)
             }
         }
     }


### PR DESCRIPTION
We were having a code smell on iOS when handling user property counters:
```
increment(.numberOfRoundsUsingAppleWatch(0))
```

Because destinations belonged to a `Property` and were not associated with the `PropertyType` (before `PropertyName`), it was not possible to increment a property without passing a value (which was not used in the end).

```
increment(.numberOfRoundsUsingAppleWatch)
```

This PR fixes that by moving the `destinations` to the `PropertyType`. The same thing was done in `EventType` for consistency and to prevent the same code smell from appearing again.