### PR TITLE
Put Kotlin class properties each in their own line to avoid huge lines and improve readability

### DIFF
--- a/lib/evva/templates/kotlin/events.kt
+++ b/lib/evva/templates/kotlin/events.kt
@@ -10,7 +10,9 @@ sealed class <%= class_name %>(
     object <%= e[:class_name] %> : <%= class_name %>(
     <%- else -%>
     data class <%= e[:class_name] %>(
-        <%= e[:properties].map { |p| "val #{p[:param_name]}: #{p[:type]}" }.join(", ") %>
+        <%- e[:properties].each_with_index do |p, index| -%>
+        <%= "val #{p[:param_name]}: #{p[:type]}" %><% if index < e[:properties].count - 1 %>,<% end %>
+        <%- end -%>
     ) : <%= class_name %>(
     <%- end -%>
         event = <%= enums_class_name %>.<%= e[:event_name] %>,

--- a/spec/lib/evva/android_generator_spec.rb
+++ b/spec/lib/evva/android_generator_spec.rb
@@ -40,7 +40,8 @@ sealed class AnalyticsEvent(
     )
 
     data class CpPageViewA(
-        val courseId: Long, val courseName: String
+        val courseId: Long,
+        val courseName: String
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_A,
         properties = mapOf(
@@ -54,7 +55,9 @@ sealed class AnalyticsEvent(
     )
 
     data class CpPageViewB(
-        val courseId: Long, val courseName: String, val fromScreen: CourseProfileSource
+        val courseId: Long,
+        val courseName: String,
+        val fromScreen: CourseProfileSource
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_B,
         properties = mapOf(
@@ -68,7 +71,9 @@ sealed class AnalyticsEvent(
     )
 
     data class CpPageViewC(
-        val courseId: Long, val courseName: String, val fromScreen: CourseProfileSource?
+        val courseId: Long,
+        val courseName: String,
+        val fromScreen: CourseProfileSource?
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_C,
         properties = mapOf(
@@ -79,7 +84,9 @@ sealed class AnalyticsEvent(
     )
 
     data class CpPageViewD(
-        val courseId: Long?, val courseName: String, val viewedAt: String
+        val courseId: Long?,
+        val courseName: String,
+        val viewedAt: String
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_D,
         properties = mapOf(


### PR DESCRIPTION
This PR changes Kotlin code generation from this:
```
data class Event(
    val id: Long, val name: String
) : AnalyticsEvent
```

to this:
```
data class Event(
    val id: Long,
    val name: String
) : AnalyticsEvent
```

This guarantees that there aren't huge lines, which improves the readability of the code and conforms to coding style guidelines.
