### PR TITLE
Kotlin enums update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+### Breaking Changes
+- Update to Kotlin 2.0 notation which doesn't require a ';' in the last item of an enum
 
 ## [0.4.3] - 2023-09-14
 - Put class properties in newline for Kotlin

--- a/lib/evva/templates/kotlin/destinations.kt
+++ b/lib/evva/templates/kotlin/destinations.kt
@@ -1,5 +1,5 @@
 enum class <%= class_name %> {
 	<%- destinations.each_with_index do |destination, index| -%>
-	<%= destination %><%= index == destinations.count - 1 ? ";" : "," %>
+	<%= destination %><%= index == destinations.count - 1 ? "" : "," %>
 	<%- end -%>
 }

--- a/lib/evva/templates/kotlin/event_enum.kt
+++ b/lib/evva/templates/kotlin/event_enum.kt
@@ -1,5 +1,5 @@
 enum class <%= class_name %>(val key: String) {
 	<%- events.each_with_index do |event, index| -%>
-	<%= event[:name] %>("<%= event[:value] %>")<%= index == events.count - 1 ? ";" : "," %>
+	<%= event[:name] %>("<%= event[:value] %>")<%= index == events.count - 1 ? "" : "," %>
 	<%- end -%>
 }

--- a/lib/evva/templates/kotlin/people_properties_enum.kt
+++ b/lib/evva/templates/kotlin/people_properties_enum.kt
@@ -1,5 +1,5 @@
 enum class <%= class_name %>(val key: String) {
 	<%- properties.each_with_index do |property, index| -%>
-	<%= property[:name] %>("<%= property[:value] %>")<%= index == properties.count - 1 ? ";" : "," %>
+	<%= property[:name] %>("<%= property[:value] %>")<%= index == properties.count - 1 ? "" : "," %>
 	<%- end -%>
 }

--- a/lib/evva/templates/kotlin/special_property_enums.kt
+++ b/lib/evva/templates/kotlin/special_property_enums.kt
@@ -1,7 +1,7 @@
 <%- enums.each_with_index do |enum, index| -%>
 enum class <%= enum[:class_name] %>(val key: String) {
 	<%- enum[:values].each_with_index do |v, index| -%>
-	<%= v[:name] %>("<%= v[:value] %>")<%= index == enum[:values].count - 1 ? ";" : "," %>
+	<%= v[:name] %>("<%= v[:value] %>")<%= index == enum[:values].count - 1 ? "" : "," %>
 	<%- end -%>
 }
 <%- unless index == enums.count - 1 -%>

--- a/spec/lib/evva/android_generator_spec.rb
+++ b/spec/lib/evva/android_generator_spec.rb
@@ -118,12 +118,12 @@ package com.hole19golf.hole19.analytics
 
 enum class CourseProfileSource(val key: String) {
     COURSE_DISCOVERY("course_discovery"),
-    SYNCED_COURSES("synced_courses");
+    SYNCED_COURSES("synced_courses")
 }
 
 enum class PremiumFrom(val key: String) {
     COURSE_PROFILE("Course Profile"),
-    ROUND_SETUP("Round Setup");
+    ROUND_SETUP("Round Setup")
 }
 Kotlin
      }
@@ -146,7 +146,7 @@ package com.hole19golf.hole19.analytics
 
 enum class AnalyticsEvents(val key: String) {
     NAV_FEED_TAP("nav_feed_tap"),
-    NAV_PERFORMANCE_TAP("nav_performance_tap");
+    NAV_PERFORMANCE_TAP("nav_performance_tap")
 }
 Kotlin
      }
@@ -222,7 +222,7 @@ package com.hole19golf.hole19.analytics
 
 enum class AnalyticsProperties(val key: String) {
     ROUNDS_WITH_WEAR("rounds_with_wear"),
-    WEAR_PLATFORM("wear_platform");
+    WEAR_PLATFORM("wear_platform")
 }
 Kotlin
     }
@@ -245,7 +245,7 @@ package com.hole19golf.hole19.analytics
 
 enum class AnalyticsDestinations {
     FIREBASE,
-    WHATEVER_YOU_WANT_REALLY;
+    WHATEVER_YOU_WANT_REALLY
 }
 Kotlin
     }


### PR DESCRIPTION
After updating our Kotlin/Detekt version, enums no longer should have a `;` at the end.

Example:

```
enum class AnalyticsDestinations {
    MIXPANEL,
    KOCHAVA,
    BRAZE,
    FIREBASE;
}
```

Becomes:

```
enum class AnalyticsDestinations {
    MIXPANEL,
    KOCHAVA,
    BRAZE,
    FIREBASE
}
```