### PR TITLE
Kotlin Bool/Boolean interoperability 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Kotlin support for handling "identifier:Bool "
+
 ## [0.5.0] - 2024-10-16
 
 - Update all dependencies

--- a/lib/evva/kotlin_generator.rb
+++ b/lib/evva/kotlin_generator.rb
@@ -177,7 +177,8 @@ module Evva
 
     def native_type(type)
       type
-        .gsub("Date","String")
+        .gsub("Date", "String")
+        .gsub(/\bBool\b/, "Boolean")
     end
 
     def is_special_property?(type)

--- a/spec/lib/evva/kotlin_generator_spec.rb
+++ b/spec/lib/evva/kotlin_generator_spec.rb
@@ -11,6 +11,7 @@ describe Evva::KotlinGenerator do
       Evva::AnalyticsEvent.new("cp_page_view_b", { course_id: "Long", course_name: "String", from_screen: "CourseProfileSource" }, ["firebase"]),
       Evva::AnalyticsEvent.new("cp_page_view_c", { course_id: "Long", course_name: "String", from_screen: "CourseProfileSource?" }, []),
       Evva::AnalyticsEvent.new("cp_page_view_d", { course_id: "Long?", course_name: "String", viewed_at: "Date" }, []),
+      Evva::AnalyticsEvent.new("example_booleans", { example_bool: "Bool", example_boolean: "Boolean" }, []),
     ] }
 
     let(:expected) {
@@ -93,6 +94,17 @@ sealed class AnalyticsEvent(
             "course_id" to courseId,
             "course_name" to courseName,
             "viewed_at" to viewedAt
+        ),
+    )
+
+    data class ExampleBooleans(
+        val exampleBool: Boolean,
+        val exampleBoolean: Boolean
+    ) : AnalyticsEvent(
+        event = AnalyticsEvents.EXAMPLE_BOOLEANS,
+        properties = mapOf(
+            "example_bool" to exampleBool,
+            "example_boolean" to exampleBoolean
         ),
     )
 }

--- a/spec/lib/evva/swift_generator_spec.rb
+++ b/spec/lib/evva/swift_generator_spec.rb
@@ -10,6 +10,7 @@ describe Evva::SwiftGenerator do
       Evva::AnalyticsEvent.new("cp_page_view_b", { course_id: "Long", course_name: "String", from_screen: "CourseProfileSource" }, []),
       Evva::AnalyticsEvent.new("cp_page_view_c", { course_id: "Long", course_name: "String", from_screen: "CourseProfileSource?" }, []),
       Evva::AnalyticsEvent.new("cp_page_view_d", { course_id: "Long?", course_name: "String" }, []),
+      Evva::AnalyticsEvent.new("example_booleans", { example_bool: "Bool", example_boolean: "Boolean" }, []),
     ] }
 
     let(:expected) {
@@ -41,6 +42,7 @@ extension Analytics {
         case cpPageViewB = "cp_page_view_b"
         case cpPageViewC = "cp_page_view_c"
         case cpPageViewD = "cp_page_view_d"
+        case exampleBooleans = "example_booleans"
 
         var name: String { return rawValue }
 
@@ -51,6 +53,7 @@ extension Analytics {
             case .cpPageViewB: return []
             case .cpPageViewC: return []
             case .cpPageViewD: return []
+            case .exampleBooleans: return []
             }
         }
     }
@@ -61,6 +64,7 @@ extension Analytics {
         case cpPageViewB(course_id: Int, course_name: String, from_screen: CourseProfileSource)
         case cpPageViewC(course_id: Int, course_name: String, from_screen: CourseProfileSource?)
         case cpPageViewD(course_id: Int?, course_name: String)
+        case exampleBooleans(example_bool: Bool, example_boolean: Bool)
 
         var data: EventData {
             switch self {
@@ -96,6 +100,13 @@ extension Analytics {
                                  properties: [
                                     "course_id": course_id as Any,
                                     "course_name": course_name as Any,
+                                 ])
+
+            case let .exampleBooleans(example_bool, example_boolean):
+                return EventData(type: .exampleBooleans,
+                                 properties: [
+                                    "example_bool": example_bool as Any,
+                                    "example_boolean": example_boolean as Any,
                                  ])
             }
         }


### PR DESCRIPTION
Adds support so that Kotlin can handle both Bool or Boolean from the specification.
(Swift already has an implementation for this)