### PR TITLE
Add exclude_destinations configuration option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `exclude_destinations` configuration to filter out specific destinations from generated code
+
 ## [0.7.0] - 2026-04-07
 
 - Add `swift_public` configuration which modifies the accessibility of all the Swift code extensions to `public`

--- a/lib/evva.rb
+++ b/lib/evva.rb
@@ -25,6 +25,7 @@ module Evva
 
     config = Evva::Config.new(hash: YAML.safe_load(config_file))
     bundle = analytics_data(config: config.data_source)
+    filter_destinations!(bundle, config.exclude_destinations)
     case config.type.downcase
     when "android"
       generator = Evva::KotlinGenerator.new(config.package_name)
@@ -91,6 +92,14 @@ module Evva
     opts_parser.parse!(options)
 
     opts_hash
+  end
+
+  def filter_destinations!(bundle, excluded)
+    return if excluded.empty?
+
+    bundle[:destinations].reject! { |d| excluded.include?(d) }
+    bundle[:events].each { |e| e.destinations.reject! { |d| excluded.include?(d) } }
+    bundle[:people].each { |p| p.destinations.reject! { |d| excluded.include?(d) } }
   end
 
   def write_to_file(path, data)

--- a/lib/evva/config.rb
+++ b/lib/evva/config.rb
@@ -13,6 +13,7 @@ module Evva
       if @hash.key?(:swift_public) && ![true, false].include?(@hash[:swift_public])
         raise ArgumentError, "swift_public must be true or false"
       end
+
     end
 
     def to_h
@@ -63,6 +64,10 @@ module Evva
       @hash[:swift_public] == true
     end
 
+    def exclude_destinations
+      @hash[:exclude_destinations] || []
+    end
+
     CONFIG_STRUCT = {
       type: Hash,
       elements: {
@@ -77,7 +82,8 @@ module Evva
         people_enum_file_name: { type: String },
         destinations_file_name: { type: String },
         package_name: { type: String },
-        swift_public: { type: Object, optional: true }
+        swift_public: { type: Object, optional: true },
+        exclude_destinations: { type: Array, optional: true }
       }
     }.freeze
 

--- a/spec/evva_spec.rb
+++ b/spec/evva_spec.rb
@@ -23,6 +23,40 @@ describe Evva do
     end
   end
 
+  describe ".filter_destinations!" do
+    let(:bundle) do
+      {
+        destinations: ["firebase", "mixpanel"],
+        events: [Evva::AnalyticsEvent.new("test_event", {}, ["firebase", "mixpanel"])],
+        people: [Evva::AnalyticsProperty.new("test_prop", "String", ["firebase", "mixpanel"])],
+      }
+    end
+
+    context "when excluding a destination" do
+      before { Evva.filter_destinations!(bundle, ["firebase"]) }
+
+      it "removes it from the destinations list" do
+        expect(bundle[:destinations]).to eq(["mixpanel"])
+      end
+
+      it "removes it from event destinations" do
+        expect(bundle[:events].first.destinations).to eq(["mixpanel"])
+      end
+
+      it "removes it from people property destinations" do
+        expect(bundle[:people].first.destinations).to eq(["mixpanel"])
+      end
+    end
+
+    context "when exclude list is empty" do
+      before { Evva.filter_destinations!(bundle, []) }
+
+      it "does not change anything" do
+        expect(bundle[:destinations]).to eq(["firebase", "mixpanel"])
+      end
+    end
+  end
+
   context "when generic.yml does not exist locally" do
     let(:error) { "Could not open yml file" }
     before do

--- a/spec/lib/evva/config_spec.rb
+++ b/spec/lib/evva/config_spec.rb
@@ -47,6 +47,24 @@ describe Evva::Config do
     end
   end
 
+  describe "#exclude_destinations" do
+    context "when not set" do
+      its(:exclude_destinations) { should eq([]) }
+    end
+
+    context "when set to an array" do
+      before { hash[:exclude_destinations] = ["firebase"] }
+
+      its(:exclude_destinations) { should eq(["firebase"]) }
+    end
+
+    context "when not an array" do
+      before { hash[:exclude_destinations] = "firebase" }
+
+      it { expect { config }.to raise_error(ArgumentError, /Expected Array, got String/) }
+    end
+  end
+
   describe "#swift_public?" do
     context "when swift_public is true" do
       before { hash[:swift_public] = true }


### PR DESCRIPTION
## Summary
- Add `exclude_destinations` optional config parameter that accepts an array of destination names to filter out during code generation
- Filters excluded destinations from the destinations list, event destinations, and people property destinations
- Useful for projects that don't use all destinations (e.g., iOS project that doesn't use Firebase)

## Usage

```yaml
# evva_config.yml
exclude_destinations:
  - firebase
```

## Test plan
- [x] Config spec: defaults to empty array when not set
- [x] Config spec: accepts an array of strings
- [x] Config spec: raises error when not an array
- [x] Integration spec: filters destinations from destinations list
- [x] Integration spec: filters destinations from event destinations
- [x] Integration spec: filters destinations from people property destinations
- [x] Integration spec: no-op when exclude list is empty
- [x] All 67 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)