### PR TITLE
Fix Swift codegen: optional chaining, reserved keywords, redundant public

### DIFF
--- a/lib/evva/swift_generator.rb
+++ b/lib/evva/swift_generator.rb
@@ -64,6 +64,7 @@ module Evva
             property_name: p.property_name,
             type: type,
             is_special_property: special_property?(type),
+            is_optional: type.end_with?("?"),
             destinations: p.destinations.map { |p| camelize(p) },
           }
         end

--- a/lib/evva/swift_generator.rb
+++ b/lib/evva/swift_generator.rb
@@ -11,6 +11,7 @@ module Evva
     TAB_SIZE = "    " # \t -> 4 spaces
 
     NATIVE_TYPES = %w[Int String Double Float Bool Date].freeze
+    SWIFT_KEYWORDS = %w[default].freeze
 
     def initialize(swift_public: false)
       @swift_public_modifier = swift_public ? "public " : ""
@@ -137,6 +138,7 @@ module Evva
       string = string.sub(/^(?:#{@acronym_regex}(?=\b|[A-Z_])|\w)/) { |match| match.downcase }
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{$2.capitalize}" }
       string.gsub!("/".freeze, "::".freeze)
+      string = "`#{string}`" if SWIFT_KEYWORDS.include?(string)
       string
     end
   end

--- a/lib/evva/templates/swift/destinations.swift
+++ b/lib/evva/templates/swift/destinations.swift
@@ -1,4 +1,4 @@
-<%= @swift_public_modifier %>enum Destination {
+enum Destination {
 	<%- destinations.each do |d| -%>
 	case <%= d %>
 	<%- end -%>

--- a/lib/evva/templates/swift/people_properties.swift
+++ b/lib/evva/templates/swift/people_properties.swift
@@ -40,7 +40,7 @@ enum Property {
 		<%- properties.each_with_index do |p, index| -%>
 		case let .<%= p[:case_name] %>(value):
 			return PropertyData(type: .<%= p[:case_name] %>,
-								value: value<% if p[:is_special_property] %>.rawValue<% end %>)
+								value: value<% if p[:is_special_property] %><%= "?" if p[:is_optional] %>.rawValue<% end %>)
 			<%- unless index == properties.count - 1 -%>
 
 			<%- end -%>

--- a/spec/lib/evva/swift_generator_spec.rb
+++ b/spec/lib/evva/swift_generator_spec.rb
@@ -263,7 +263,7 @@ Swift
 import Foundation
 
 public extension Analytics {
-    public enum Destination {
+    enum Destination {
         case firebase
         case whateverYouWantReally
     }

--- a/spec/lib/evva/swift_generator_spec.rb
+++ b/spec/lib/evva/swift_generator_spec.rb
@@ -113,6 +113,7 @@ Swift
     let(:enums) { [
       Evva::AnalyticsEnum.new("CourseProfileSource", ["course_discovery", "synced_courses"]),
       Evva::AnalyticsEnum.new("PremiumFrom", ["Course Profile", "Round Setup"]),
+      Evva::AnalyticsEnum.new("PreAuthenticationScreenType", ["default", "self_improvement"]),
     ] }
 
     let(:expected) {
@@ -130,6 +131,11 @@ extension Analytics {
     enum PremiumFrom: String {
         case courseProfile = "Course Profile"
         case roundSetup = "Round Setup"
+    }
+
+    enum PreAuthenticationScreenType: String {
+        case `default` = "default"
+        case selfImprovement = "self_improvement"
     }
 }
 Swift

--- a/spec/lib/evva/swift_generator_spec.rb
+++ b/spec/lib/evva/swift_generator_spec.rb
@@ -144,6 +144,7 @@ Swift
     let(:people_bundle) { [
       Evva::AnalyticsProperty.new("rounds_with_wear", "String", ["firebase"]),
       Evva::AnalyticsProperty.new("wear_platform", "WearableAppPlatform", ["firebase", "custom destination"]),
+      Evva::AnalyticsProperty.new("reverse_trial_type", "ReverseTrialType?", ["firebase"]),
       Evva::AnalyticsProperty.new("number_of_times_it_happened", "Long", []),
     ] }
 
@@ -173,6 +174,7 @@ extension Analytics {
     enum PropertyType: String {
         case roundsWithWear = "rounds_with_wear"
         case wearPlatform = "wear_platform"
+        case reverseTrialType = "reverse_trial_type"
         case numberOfTimesItHappened = "number_of_times_it_happened"
 
         var name: String { return rawValue }
@@ -181,6 +183,7 @@ extension Analytics {
             switch self {
             case .roundsWithWear: return [.firebase]
             case .wearPlatform: return [.firebase, .customDestination]
+            case .reverseTrialType: return [.firebase]
             case .numberOfTimesItHappened: return []
             }
         }
@@ -189,6 +192,7 @@ extension Analytics {
     enum Property {
         case roundsWithWear(String)
         case wearPlatform(WearableAppPlatform)
+        case reverseTrialType(ReverseTrialType?)
         case numberOfTimesItHappened(Int)
 
         var data: PropertyData {
@@ -200,6 +204,10 @@ extension Analytics {
             case let .wearPlatform(value):
                 return PropertyData(type: .wearPlatform,
                                     value: value.rawValue)
+
+            case let .reverseTrialType(value):
+                return PropertyData(type: .reverseTrialType,
+                                    value: value?.rawValue)
 
             case let .numberOfTimesItHappened(value):
                 return PropertyData(type: .numberOfTimesItHappened,


### PR DESCRIPTION
## Summary
- **Optional chaining**: Property value expressions for optional enum types now emit `value?.rawValue` instead of `value.rawValue`, fixing a Swift compilation error
- **Reserved keywords**: Enum case names that are Swift reserved keywords (e.g. `default`) are now escaped with backticks
- **Redundant public modifier**: Removed `public` from `enum Destination` inside `public extension`, eliminating the Swift compiler warning

## Test plan
- [x] Added optional enum property (`ReverseTrialType?`) to people_properties spec — verifies `value?.rawValue`
- [x] Added `"default"` enum value to special_property_enums spec — verifies backtick escaping
- [x] Updated swift_public destinations spec — verifies no redundant `public` modifier
- [x] All 67 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)