### PR TITLE
Fix double space in Swift generated parameter types

### DIFF
--- a/lib/evva/google_sheet.rb
+++ b/lib/evva/google_sheet.rb
@@ -101,8 +101,8 @@ module Evva
       unless property_array.nil? || property_array.empty?
         property_array.split(",").each do |prop|
           split_prop = prop.split(":")
-          prop_name = split_prop[0].to_sym
-          prop_type = split_prop[1].to_s
+          prop_name = split_prop[0].strip.to_sym
+          prop_type = split_prop[1].to_s.strip
           h[prop_name] = prop_type
         end
       end

--- a/spec/fixtures/sample_public_events.csv
+++ b/spec/fixtures/sample_public_events.csv
@@ -2,3 +2,4 @@ Event Name,Event Properties,Event Destination
 cp_page_view,"course_id:Long,course_name:String","firebase,custom destination"
 nav_feed_tap,,
 cp_view_scorecard,"course_id:Long,course_name:String","custom destination"
+side_game_delete,"fromScreen: SideGameFromScreen,round_group_creation_token:String",firebase

--- a/spec/lib/evva/google_sheet_spec.rb
+++ b/spec/lib/evva/google_sheet_spec.rb
@@ -26,6 +26,7 @@ describe Evva::GoogleSheet do
         Evva::AnalyticsEvent.new("cp_page_view", { course_id: "Long", course_name: "String" }, ["firebase", "custom destination"]),
         Evva::AnalyticsEvent.new("nav_feed_tap", {}, []),
         Evva::AnalyticsEvent.new("cp_view_scorecard", { course_id: "Long", course_name: "String" }, ["custom destination"]),
+        Evva::AnalyticsEvent.new("side_game_delete", { fromScreen: "SideGameFromScreen", round_group_creation_token: "String" }, ["firebase"]),
       ]
       expect(events).to eq(expected)
     end


### PR DESCRIPTION
## Summary
- Strip whitespace from property names and types when parsing CSV spreadsheet data
- Fixes cases where `fromScreen: SideGameFromScreen` in the spreadsheet produced `fromScreen:  SideGameFromScreen` (double space) in generated Swift code

## Test plan
- [x] Added CSV fixture with space after colon (`fromScreen: SideGameFromScreen`)
- [x] Verified test fails before fix (type has leading space)
- [x] All 67 tests pass after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)