### PR TITLE
Add 'as Any' cast for optional people property values

### DIFF
--- a/lib/evva/templates/swift/people_properties.swift
+++ b/lib/evva/templates/swift/people_properties.swift
@@ -40,7 +40,7 @@ enum Property {
 		<%- properties.each_with_index do |p, index| -%>
 		case let .<%= p[:case_name] %>(value):
 			return PropertyData(type: .<%= p[:case_name] %>,
-								value: value<% if p[:is_special_property] %><%= "?" if p[:is_optional] %>.rawValue<% end %>)
+								value: value<% if p[:is_special_property] %><%= "?" if p[:is_optional] %>.rawValue<% end %><%= " as Any" if p[:is_optional] %>)
 			<%- unless index == properties.count - 1 -%>
 
 			<%- end -%>

--- a/spec/lib/evva/swift_generator_spec.rb
+++ b/spec/lib/evva/swift_generator_spec.rb
@@ -213,7 +213,7 @@ extension Analytics {
 
             case let .reverseTrialType(value):
                 return PropertyData(type: .reverseTrialType,
-                                    value: value?.rawValue)
+                                    value: value?.rawValue as Any)
 
             case let .numberOfTimesItHappened(value):
                 return PropertyData(type: .numberOfTimesItHappened,


### PR DESCRIPTION
## Summary
- Optional property values like `value?.rawValue` produce a Swift compiler warning when implicitly coerced to `Any`
- Non-optional values coerce silently, so only optional expressions need the explicit `as Any` cast
- Now emits `value?.rawValue as Any` for optional enum properties

## Test plan
- [x] Updated `reverseTrialType` expected output to include `as Any`
- [x] All 67 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)