### PR TITLE
Add trailing commas to all generated Kotlin declarations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    evva (0.7.0)
+    evva (0.8.3)
       colorize (~> 1.0)
       csv (>= 3.0)
       safe_yaml (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    evva (0.8.3)
+    evva (0.8.4)
       colorize (~> 1.0)
       csv (>= 3.0)
       safe_yaml (~> 1.0)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.8.4] - 2026-06-25
+
+- Add trailing commas to all generated Kotlin declarations
+
 ## [0.8.3] - 2026-05-27
 
 - Add explicit `as Any` cast for optional people property values to silence Swift compiler warning

--- a/lib/evva/templates/kotlin/destinations.kt
+++ b/lib/evva/templates/kotlin/destinations.kt
@@ -1,5 +1,5 @@
 enum class <%= class_name %> {
 	<%- destinations.each_with_index do |destination, index| -%>
-	<%= destination %><%= index == destinations.count - 1 ? "" : "," %>
+	<%= destination %>,
 	<%- end -%>
 }

--- a/lib/evva/templates/kotlin/event_enum.kt
+++ b/lib/evva/templates/kotlin/event_enum.kt
@@ -1,5 +1,5 @@
 enum class <%= class_name %>(val key: String) {
 	<%- events.each_with_index do |event, index| -%>
-	<%= event[:name] %>("<%= event[:value] %>")<%= index == events.count - 1 ? "" : "," %>
+	<%= event[:name] %>("<%= event[:value] %>"),
 	<%- end -%>
 }

--- a/lib/evva/templates/kotlin/events.kt
+++ b/lib/evva/templates/kotlin/events.kt
@@ -1,7 +1,7 @@
 sealed class <%= class_name %>(
     event: <%= enums_class_name %>,
     val properties: Map<String, Any?>? = null,
-    val destinations: Array<<%= destinations_class_name %>> = emptyArray()
+    val destinations: Array<<%= destinations_class_name %>> = emptyArray(),
 ) {
     val name = event.key
 
@@ -11,7 +11,7 @@ sealed class <%= class_name %>(
     <%- else -%>
     data class <%= e[:class_name] %>(
         <%- e[:properties].each_with_index do |p, index| -%>
-        <%= "val #{p[:param_name]}: #{p[:type]}" %><% if index < e[:properties].count - 1 %>,<% end %>
+        <%= "val #{p[:param_name]}: #{p[:type]}" %>,
         <%- end -%>
     ) : <%= class_name %>(
     <%- end -%>
@@ -19,16 +19,16 @@ sealed class <%= class_name %>(
         <%- if e[:properties].count > 0 -%>
         properties = mapOf(
             <%- e[:properties].each_with_index do |p, index| -%>
-            "<%= p[:name] %>" to <%= p[:value_fetcher] %><% if index < e[:properties].count - 1 %>,<% end %>
+            "<%= p[:name] %>" to <%= p[:value_fetcher] %>,
             <%- end -%>
         ),
         <%- end -%>
         <%- if e[:destinations].count > 0 -%>
         destinations = arrayOf(
             <%- e[:destinations].each_with_index do |d, index| -%>
-            <%= destinations_class_name %>.<%= d %><% if index < e[:destinations].count - 1 %>,<% end %>
+            <%= destinations_class_name %>.<%= d %>,
             <%- end -%>
-        )
+        ),
         <%- end -%>
     )
     <%- unless index == events.count - 1 -%>

--- a/lib/evva/templates/kotlin/people_properties.kt
+++ b/lib/evva/templates/kotlin/people_properties.kt
@@ -1,22 +1,22 @@
 sealed class <%= class_name %>(
 	property: <%= enums_class_name %>,
 	val innerValue: Any,
-	val destinations: Array<<%= destinations_class_name %>> = emptyArray()
+	val destinations: Array<<%= destinations_class_name %>> = emptyArray(),
 ) {
 	val name = property.key
 
 	<%- properties.each_with_index do |property, index| -%>
 	data class <%= property[:class_name] %>(
-		val value: <%= property[:type] %>
+		val value: <%= property[:type] %>,
 	) : <%= class_name %>(
 		property = <%= enums_class_name %>.<%= property[:property_name] %>,
 		innerValue = value<% if property[:is_special_property] %>.key<% end %>,
 		<%- if property[:destinations].count > 0 -%>
 		destinations = arrayOf(
 			<%- property[:destinations].each_with_index do |d, index| -%>
-			<%= destinations_class_name %>.<%= d %><% if index < property[:destinations].count - 1 %>,<% end %>
+			<%= destinations_class_name %>.<%= d %>,
 			<%- end -%>
-		)
+		),
 		<%- end -%>
 	)
 	<%- unless index == properties.count - 1 -%>

--- a/lib/evva/templates/kotlin/people_properties_enum.kt
+++ b/lib/evva/templates/kotlin/people_properties_enum.kt
@@ -1,5 +1,5 @@
 enum class <%= class_name %>(val key: String) {
 	<%- properties.each_with_index do |property, index| -%>
-	<%= property[:name] %>("<%= property[:value] %>")<%= index == properties.count - 1 ? "" : "," %>
+	<%= property[:name] %>("<%= property[:value] %>"),
 	<%- end -%>
 }

--- a/lib/evva/templates/kotlin/special_property_enums.kt
+++ b/lib/evva/templates/kotlin/special_property_enums.kt
@@ -1,7 +1,7 @@
 <%- enums.each_with_index do |enum, index| -%>
 enum class <%= enum[:class_name] %>(val key: String) {
 	<%- enum[:values].each_with_index do |v, index| -%>
-	<%= v[:name] %>("<%= v[:value] %>")<%= index == enum[:values].count - 1 ? "" : "," %>
+	<%= v[:name] %>("<%= v[:value] %>"),
 	<%- end -%>
 }
 <%- unless index == enums.count - 1 -%>

--- a/lib/evva/version.rb
+++ b/lib/evva/version.rb
@@ -1,4 +1,4 @@
 module Evva
-  VERSION = "0.8.3".freeze
-  VERSION_UPDATED_AT = "2026-05-26".freeze
+  VERSION = "0.8.4".freeze
+  VERSION_UPDATED_AT = "2026-06-25".freeze
 end

--- a/spec/lib/evva/kotlin_generator_spec.rb
+++ b/spec/lib/evva/kotlin_generator_spec.rb
@@ -24,7 +24,7 @@ package com.hole19golf.hole19.analytics
 sealed class AnalyticsEvent(
     event: AnalyticsEvents,
     val properties: Map<String, Any?>? = null,
-    val destinations: Array<AnalyticsDestinations> = emptyArray()
+    val destinations: Array<AnalyticsDestinations> = emptyArray(),
 ) {
     val name = event.key
 
@@ -35,64 +35,64 @@ sealed class AnalyticsEvent(
     data object CpPageView2 : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_2,
         destinations = arrayOf(
-            AnalyticsDestinations.FIREBASE
-        )
+            AnalyticsDestinations.FIREBASE,
+        ),
     )
 
     data class CpPageViewA(
         val courseId: Long,
-        val courseName: String
+        val courseName: String,
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_A,
         properties = mapOf(
             "course_id" to courseId,
-            "course_name" to courseName
+            "course_name" to courseName,
         ),
         destinations = arrayOf(
             AnalyticsDestinations.FIREBASE,
-            AnalyticsDestinations.CUSTOM_DESTINATION
-        )
+            AnalyticsDestinations.CUSTOM_DESTINATION,
+        ),
     )
 
     data class CpPageViewB(
         val courseId: Long,
         val courseName: String,
-        val fromScreen: CourseProfileSource
+        val fromScreen: CourseProfileSource,
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_B,
         properties = mapOf(
             "course_id" to courseId,
             "course_name" to courseName,
-            "from_screen" to fromScreen.key
+            "from_screen" to fromScreen.key,
         ),
         destinations = arrayOf(
-            AnalyticsDestinations.FIREBASE
-        )
+            AnalyticsDestinations.FIREBASE,
+        ),
     )
 
     data class CpPageViewC(
         val courseId: Long,
         val courseName: String,
-        val fromScreen: CourseProfileSource?
+        val fromScreen: CourseProfileSource?,
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_C,
         properties = mapOf(
             "course_id" to courseId,
             "course_name" to courseName,
-            "from_screen" to fromScreen?.key
+            "from_screen" to fromScreen?.key,
         ),
     )
 
     data class CpPageViewD(
         val courseId: Long?,
         val courseName: String,
-        val viewedAt: String
+        val viewedAt: String,
     ) : AnalyticsEvent(
         event = AnalyticsEvents.CP_PAGE_VIEW_D,
         properties = mapOf(
             "course_id" to courseId,
             "course_name" to courseName,
-            "viewed_at" to viewedAt
+            "viewed_at" to viewedAt,
         ),
     )
 }
@@ -118,12 +118,12 @@ package com.hole19golf.hole19.analytics
 
 enum class CourseProfileSource(val key: String) {
     COURSE_DISCOVERY("course_discovery"),
-    SYNCED_COURSES("synced_courses")
+    SYNCED_COURSES("synced_courses"),
 }
 
 enum class PremiumFrom(val key: String) {
     COURSE_PROFILE("Course Profile"),
-    ROUND_SETUP("Round Setup")
+    ROUND_SETUP("Round Setup"),
 }
 Kotlin
      }
@@ -146,7 +146,7 @@ package com.hole19golf.hole19.analytics
 
 enum class AnalyticsEvents(val key: String) {
     NAV_FEED_TAP("nav_feed_tap"),
-    NAV_PERFORMANCE_TAP("nav_performance_tap")
+    NAV_PERFORMANCE_TAP("nav_performance_tap"),
 }
 Kotlin
      }
@@ -171,33 +171,33 @@ package com.hole19golf.hole19.analytics
 sealed class AnalyticsProperty(
     property: AnalyticsProperties,
     val innerValue: Any,
-    val destinations: Array<AnalyticsDestinations> = emptyArray()
+    val destinations: Array<AnalyticsDestinations> = emptyArray(),
 ) {
     val name = property.key
 
     data class RoundsWithWear(
-        val value: String
+        val value: String,
     ) : AnalyticsProperty(
         property = AnalyticsProperties.ROUNDS_WITH_WEAR,
         innerValue = value,
     )
 
     data class LastActiveAt(
-        val value: String
+        val value: String,
     ) : AnalyticsProperty(
         property = AnalyticsProperties.LAST_ACTIVE_AT,
         innerValue = value,
     )
 
     data class WearPlatform(
-        val value: WearableAppPlatform
+        val value: WearableAppPlatform,
     ) : AnalyticsProperty(
         property = AnalyticsProperties.WEAR_PLATFORM,
         innerValue = value.key,
         destinations = arrayOf(
             AnalyticsDestinations.FIREBASE,
-            AnalyticsDestinations.CUSTOM_DESTINATION
-        )
+            AnalyticsDestinations.CUSTOM_DESTINATION,
+        ),
     )
 }
 Kotlin
@@ -222,7 +222,7 @@ package com.hole19golf.hole19.analytics
 
 enum class AnalyticsProperties(val key: String) {
     ROUNDS_WITH_WEAR("rounds_with_wear"),
-    WEAR_PLATFORM("wear_platform")
+    WEAR_PLATFORM("wear_platform"),
 }
 Kotlin
     }
@@ -245,7 +245,7 @@ package com.hole19golf.hole19.analytics
 
 enum class AnalyticsDestinations {
     FIREBASE,
-    WHATEVER_YOU_WANT_REALLY
+    WHATEVER_YOU_WANT_REALLY,
 }
 Kotlin
     }


### PR DESCRIPTION
Generated Kotlin now emits a trailing comma on the last element of every multi-line, comma-separated construct.

## What changed
Trailing comma added to the last element of:
- sealed-class constructors (`AnalyticsEvent`, `AnalyticsProperty`)
- generated `data class` parameter lists
- `mapOf(...)` and `arrayOf(...)` entries
- enum entries (events, properties, destinations, special enums)

Touches the 6 Kotlin templates and the `kotlin_generator` spec fixtures.
Swift output is unchanged.

## Effect on consumers
Regenerating in an Android project produces only trailing-comma diffs on the generated files (verified against real sheet data).

## Testing
`bundle exec rspec` — 67 examples, 0 failures.